### PR TITLE
camlistore-configure: ask Camlistore for a working local client config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -y --no-install-recommends install git
 WORKDIR /tmp/src
 RUN git clone https://camlistore.googlesource.com/camlistore camlistore.org
 WORKDIR /tmp/src/camlistore.org
-RUN git reset --hard def28fc337ff85105b8b7dc6f0cda64af62b1615
+RUN git reset --hard 6dfe405666b7aac69df559b5414b265928a11dbd
 ENV PATH $PATH:/usr/local/go/bin
 RUN go run make.go
 RUN cp -a ./bin/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME =			camlistore
 VERSION =		latest
-VERSION_ALIASES =	def28fc337ff85105b8b7dc6f0cda64af62b1615
+VERSION_ALIASES =	6dfe405666b7aac69df559b5414b265928a11dbd
 TITLE =			Camlistore
 DESCRIPTION =		Camlistore with MySQL, pre-0.9
 SOURCE_URL =		https://github.com/scaleway-community/scaleway-camlistore


### PR DESCRIPTION
We call camput init, which asks the Camlistore help handler for an
appropriate client configuration.

This change also bumps the Camlistore version built to
6dfe405666b7aac69df559b5414b265928a11dbd because we need the recent
changes to camput init to do the above.

Fixes issue #2
Addresses issue #4